### PR TITLE
Run exiftool as one process instead of instance for every request

### DIFF
--- a/elodie/external/pyexiftool.py
+++ b/elodie/external/pyexiftool.py
@@ -151,8 +151,16 @@ def format_error (result):
         else:
             return 'exiftool finished with error: "%s"' % strip_nl(result) 
 
+class Singleton(type):
+    """Metaclass to use the singleton [anti-]pattern"""
+    instance = None
 
-class ExifTool(object):
+    def __call__(cls, *args, **kwargs):
+        if cls.instance is None:
+            cls.instance = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls.instance
+
+class ExifTool(object, metaclass=Singleton):
     """Run the `exiftool` command-line tool and communicate to it.
 
     You can pass two arguments to the constructor:

--- a/elodie/filesystem.py
+++ b/elodie/filesystem.py
@@ -18,7 +18,9 @@ from elodie.config import load_config
 from elodie.localstorage import Db
 from elodie.media.base import Base, get_all_subclasses
 from elodie.plugins.plugins import Plugins
-
+from elodie.external.pyexiftool import ExifTool
+from elodie.dependencies import get_exiftool
+from elodie import constants
 
 class FileSystem(object):
     """A class for interacting with the file system."""
@@ -48,6 +50,13 @@ class FileSystem(object):
         # Instantiate a plugins object
         self.plugins = Plugins()
 
+        #Initialize ExifTool Subprocess
+        exiftool_addedargs = [
+            u'-config',
+            u'"{}"'.format(constants.exiftool_config)
+        ]
+
+        ExifTool(executable_=get_exiftool(), addedargs=exiftool_addedargs).start()
 
     def create_directory(self, directory_path):
         """Create a directory if it does not already exist.
@@ -645,3 +654,6 @@ class FileSystem(object):
             regex_list = compiled_list
 
         return any(regex.search(path) for regex in regex_list)
+
+    def __del__(self):
+        ExifTool().terminate

--- a/elodie/media/media.py
+++ b/elodie/media/media.py
@@ -13,11 +13,8 @@ from __future__ import print_function
 import os
 
 # load modules
-from elodie import constants
-from elodie.dependencies import get_exiftool
 from elodie.external.pyexiftool import ExifTool
 from elodie.media.base import Base
-
 
 class Media(Base):
 
@@ -52,10 +49,6 @@ class Media(Base):
         self.longitude_ref_key = 'EXIF:GPSLongitudeRef'
         self.original_name_key = 'XMP:OriginalFileName'
         self.set_gps_ref = True
-        self.exiftool_addedargs = [
-            u'-config',
-            u'"{}"'.format(constants.exiftool_config)
-        ]
 
     def get_album(self):
         """Get album from EXIF
@@ -122,14 +115,16 @@ class Media(Base):
         :returns: dict, or False if exiftool was not available.
         """
         source = self.source
-        exiftool = get_exiftool()
-        if(exiftool is None):
-            return False
 
-        with ExifTool(executable_=exiftool, addedargs=self.exiftool_addedargs) as et:
-            metadata = et.get_metadata(source)
-            if not metadata:
-                return False
+        #Cache metadata results and use if already exists for media
+        if(self.metadata is None):
+            metadata = ExifTool().get_metadata(source)
+            self.metadata = metadata
+        else:
+            metadata = self.metadata
+
+        if not metadata:
+            return False
 
         return metadata
 
@@ -318,13 +313,8 @@ class Media(Base):
             return None
 
         source = self.source
-        exiftool = get_exiftool()
-        if(exiftool is None):
-            return False
-
 
         status = ''
-        with ExifTool(executable_=exiftool, addedargs=self.exiftool_addedargs) as et:
-            status = et.set_tags(tags, source)
+        ExifTool().set_tags(tags,source)
 
         return status != ''


### PR DESCRIPTION
Speeds metadata extraction up considerably